### PR TITLE
Corrections on Context

### DIFF
--- a/es-LA.lproj/Localizable.strings
+++ b/es-LA.lproj/Localizable.strings
@@ -1,14 +1,14 @@
 <dict>
     <key>DARK_MODE_ON</key>
-    <string>Modo Nocturno: Sí</string>
+    <string>Modo Nocturno: Activado</string>
     <key>DARK_MODE_OFF</key>
-    <string>Modo Nocturno: No</string>
+    <string>Modo Nocturno: Desactivado</string>
     <key>NIGHT_SHIFT_ON</key>
-    <string>Night Shift: Sí</string>
+    <string>Night Shift: Activado</string>
     <key>NIGHT_SHIFT_OFF</key>
-    <string>Night Shift: No</string>
+    <string>Night Shift: Desactivado</string>
     <key>AIRPLAY_MIRRORING</key>
-    <string>AirPlay\nDuplicando</string>
+    <string>AirPlay \nMirroring</string>
     <key>AIRDROP_OFF</key>
     <string>AirDrop:\nNo Recibir</string>
     <key>AIRDROP_CONTACTS</key>


### PR DESCRIPTION
words that i used like "Activar == Enable" or "Deactivar == Disable", insted of "si == yes", "No == No" also mirroring instead of "duplicado== Duplicate" (Which is accepted in south and central America as anglicisms and there is no official translation to it) where chosen by me since to they seem to be correct on the context and also some phrases you used (like "Cualquiera" instead of "Todo" and "Serás = you will" instead of "puedes ser = you can/ you could " are changeable in this situation. some other correction you made are correct thank you so much.
Source I'm not only Developer but also Linguist.